### PR TITLE
Изменить событие в слушателе popup

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -143,7 +143,7 @@ popups.forEach(function (popup) {
     closePopup(popup);
   });
   //Закрытие по нажатию на оверлей
-  popup.addEventListener('click', function (evt) {
+  popup.addEventListener('mousedown', function (evt) {
     if (evt.target.classList.contains('popup')) {
       closePopup(popup);
     }


### PR DESCRIPTION
Теперь закрытие попапа по нажатию на оверлей происходит при событии mousedown, а не click